### PR TITLE
Added onRequest for handling HTTP on the same port

### DIFF
--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -1,6 +1,9 @@
 import { Store } from "express-session";
+import { Server } from "ws";
 import { FlayerConfigError } from "../error";
 import { DeepRequired } from "../utils";
+
+type RequestHandler = (this: Server, ...args: any[]) => void;
 
 /**
  * Normalized server configuration.
@@ -20,6 +23,13 @@ export interface ServerConfig {
    * Default 0 (unlimited)
    */
   maxListeners?: number;
+  /**
+   * Handler for incoming HTTP requests
+   */
+  onRequest?: RequestHandler | null;
+  /**
+   * Session configuration
+   */
   session?: SessionConfig;
 }
 
@@ -87,8 +97,9 @@ export interface SessionConfig {
  * For internal use only.
  */
 export type NormalizedServerConfig = DeepRequired<
-  Omit<ServerConfig, "session">
+  Omit<ServerConfig, "onRequest" | "session">
 > & {
+  onRequest: RequestHandler | null;
   session: DeepRequired<Omit<SessionConfig, "store">> & {
     store: Store | null;
   };
@@ -108,6 +119,7 @@ export function normalizeServerConfig(
   return {
     port: config?.port ?? 1234,
     maxListeners: config?.maxListeners ?? 0,
+    onRequest: config?.onRequest ?? null,
     session: {
       cookie: {
         domain: null,

--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -18,6 +18,11 @@ export function startWebSocketServer(config: NormalizedServerConfig) {
     port,
   });
 
+  // If an onRequest handler is set, make the WS server forward requests there
+  if (config.onRequest != null) {
+    wss.on("request", config.onRequest);
+  }
+
   // Intercept handshake request when about to send headers
   wss.on("headers", (headers, req) => {
     if (config.session) {


### PR DESCRIPTION
To make it possible to run an HTTP server (static files or any other endpoints) on the same port as Flayer, there is a new server configuration `onRequest`.

After these changes you should be able to pass e.g. an Express application like this:

```ts
const app = express();

server.start({
  port: 1234,
  onRequest: app,
});
```